### PR TITLE
Update exceptions.txt

### DIFF
--- a/exceptions.txt
+++ b/exceptions.txt
@@ -171,3 +171,4 @@
 230961: 'Marsupilami (2009)', 'Marsupilami',
 75477: 'Chip & Chap', 'Chip und Chap', 'Chip und Chap - Die Ritter des Rechts',
 161461: 'Rizzoli & Isles', 'Rizzoli and Isles', 'Rizzoli und Isles',
+257564: 'Der XXL-Ostfriese', 'Der XXL Ostfriese'


### PR DESCRIPTION
Habe die exceptions um: "Der XXL-Ostfriese" erweitert. Habe die Doku selbst bei tvdb angelegt. Leider mit nem Bindestrich. In den Releases wirds ohne geschrieben.
Gruß beatlin
